### PR TITLE
Remove the need for the host application to extend AMBNApplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,8 @@ Those permissions are included in SDK’s manifest (there is no need to include 
 
 In order to integrate aimbrain SDK it is necessary to set up application name in
 project’s `AndroidManifest.xml`.
-If no `Application` class extensions are needed, use `com.aimbrain.sdk.AMBNApplication.AMBNApplication`,
-otherwise use your extension's name.
-
-```xml
-<application android:name=“com.aimbrain.sdk.AMBNApplication.AMBNApplication”>
-  ```
+In your own Application class's onCreate(), initialize Aimbrain by passing in the
+application reference by calling AMBNApplication.initialize(this).
 
 ## Configuration
 In order to communicate with the server, the application identifier and secret need to be
@@ -149,14 +145,14 @@ public class MainActivity extends AppCompatActivity {
 }
   ```
 
-If data needs to be collected since the application creation, extend `AMBNApplication`
-class as shown in the example.
+If data needs to be collected since the application creation, do so in your application's onCreate().
 
 ```java
-public class MyApplication extends AMBNApplication {
+public class MyApplication extends Application {
 	@Override
   	public void onCreate() {
     	super.onCreate();
+    	AMBNApplication.initialize(this);
     	Manager.getInstance().startCollectingData(null);
   	}
 }

--- a/aimbrain/src/main/java/com/aimbrain/sdk/AMBNApplication/AMBNApplication.java
+++ b/aimbrain/src/main/java/com/aimbrain/sdk/AMBNApplication/AMBNApplication.java
@@ -1,6 +1,7 @@
 package com.aimbrain.sdk.AMBNApplication;
 
 import android.app.Application;
+import android.content.Context;
 
 import com.aimbrain.sdk.util.Logger;
 
@@ -8,23 +9,53 @@ import com.aimbrain.sdk.util.Logger;
  * In order to integrate library into the project this class (or its descendant) should be used as an application class.
  * When extending this class, remember to call super.onCreate() in your onCreate() callback.
  */
-public class AMBNApplication extends Application {
+public class AMBNApplication {
     private static final String TAG = AMBNApplication.class.getSimpleName();
 
     private static AMBNApplication instance;
+    private static final Object lock = new Object();
+    private Application application;
 
-    @Override
-    public void onCreate() {
-        super.onCreate();
-        Logger.d(TAG, "onCreate");
-        instance = this;
+    public static AMBNApplication initialize(Application application) {
+        synchronized (lock) {
+            if (instance == null) {
+                instance = new AMBNApplication(application);
+            }
+            return instance;
+        }
+    }
+
+    private AMBNApplication(Application application) {
+        Logger.d(TAG, "Initializing AMBNApplication");
+        this.application = application;
     }
 
     /**
      * Returns singleton of the class
      * @return instance of AMBNApplication class
      */
-    public static AMBNApplication getInstance(){
-        return instance;
+    public static AMBNApplication getInstance() {
+        synchronized (lock) {
+            if (instance == null) {
+                throw new RuntimeException("Must call initialize() method on " + AMBNApplication.class.getName() + " first.");
+            }
+            return instance;
+        }
+    }
+
+    /**
+     * Get the application's context.
+     * @return the application's context.
+     */
+    public Context getAppContext() {
+        return application;
+    }
+
+    /**
+     * Get the application.
+     * @return the application.
+     */
+    public Application getApp() {
+        return application;
     }
 }

--- a/aimbrain/src/main/java/com/aimbrain/sdk/Manager.java
+++ b/aimbrain/src/main/java/com/aimbrain/sdk/Manager.java
@@ -99,7 +99,7 @@ public class Manager {
     public void startCollectingData(Window window) {
         Logger.v(TAG, "Start collecting data in " + window);
         activityLifecycleCallback = new AMBNActivityLifecycleCallback();
-        AMBNApplication.getInstance().registerActivityLifecycleCallbacks(activityLifecycleCallback);
+        AMBNApplication.getInstance().getApp().registerActivityLifecycleCallbacks(activityLifecycleCallback);
         if (window != null) {
             windowChanged(window);
         }
@@ -185,7 +185,7 @@ public class Manager {
      */
     public void stopCollectingData() {
         Logger.v(TAG, "Stop collecting data");
-        AMBNApplication.getInstance().unregisterActivityLifecycleCallbacks(activityLifecycleCallback);
+        AMBNApplication.getInstance().getApp().unregisterActivityLifecycleCallbacks(activityLifecycleCallback);
         activityLifecycleCallback = null;
         if (timer != null) {
             Logger.v(TAG, "Stop submission timer");

--- a/aimbrain/src/main/java/com/aimbrain/sdk/sensorEvent/AccelerometerEventListener.java
+++ b/aimbrain/src/main/java/com/aimbrain/sdk/sensorEvent/AccelerometerEventListener.java
@@ -19,7 +19,7 @@ public class AccelerometerEventListener implements SensorEventListener{
 
 
     public AccelerometerEventListener(int samplingPeriodMillis) {
-        this.sensorManager = (SensorManager) AMBNApplication.getInstance().getSystemService(Context.SENSOR_SERVICE);
+        this.sensorManager = (SensorManager) AMBNApplication.getInstance().getAppContext().getSystemService(Context.SENSOR_SERVICE);
         this.registered = false;
         this.samplingPeriodMillis = samplingPeriodMillis;
     }

--- a/aimbrain/src/main/java/com/aimbrain/sdk/server/Server.java
+++ b/aimbrain/src/main/java/com/aimbrain/sdk/server/Server.java
@@ -247,7 +247,7 @@ public class Server {
     }
 
     private boolean isOnline() {
-        ConnectivityManager cm = (ConnectivityManager) AMBNApplication.getInstance().getSystemService(Context.CONNECTIVITY_SERVICE);
+        ConnectivityManager cm = (ConnectivityManager) AMBNApplication.getInstance().getAppContext().getSystemService(Context.CONNECTIVITY_SERVICE);
         NetworkInfo netInfo = cm.getActiveNetworkInfo();
         return netInfo != null && netInfo.isConnected();
     }


### PR DESCRIPTION
Fixes a problem for host applications that already need to
extend a different application class.
AMBNApplication only references the application and it's
context. This adds an alternative way of initializing
AMBNApplication without the host needing to extend it
from their own Application class, just call to initialize it
with the application as a parameter instead.